### PR TITLE
Docs improvements and fix for using the check via Hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CredoMox
 
-Credo Checks for the Mox library.
+Credo Checks to ensure correct usage of the Mox library.
 
-Provides a Credo check that ensures tests that have imported Mox and use the `expect` function
-are verifying those expectations. See the `CredoMox.UnverifiedMox` module for more details.
+Provides a Credo check that ensures tests that have imported Mox and use the `Mox.expect/4` function
+are verifying those expectations. See the `CredoMox.Checks.UnverifiedMox` module for more details.
 
 ## Usage
 
@@ -14,24 +14,21 @@ add the `UnverifiedMox` module to your checks and configure it to only include t
 # ... .credo.exs
   checks: [
     ## other Credo checks...
-    {CredoMox.Checks.UnverifiedMocks, files: %{included: ["**/*_test.exs"]}},
+    {CredoMox.Checks.UnverifiedMox, files: %{included: ["**/*_test.exs"]}},
   ]
 ```
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `credo_mox` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `credo_mox` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:credo_mox, "~> 0.1.0"}
+    {:credo_mox, "~> 0.1", only: [:dev, :test], runtime: false},
   ]
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/unverified_mox>.
+Docs can be found at <https://hexdocs.pm/credo_mox>.
 

--- a/lib/checks/unverified_mox.ex
+++ b/lib/checks/unverified_mox.ex
@@ -1,129 +1,132 @@
-defmodule CredoMox.Checks.UnverifiedMox do
-  @moduledoc """
-  #{__MODULE__} looks for test files that import Mox and use
-  the `expect/4` function, but do not enforce any assertions that
-  the expectations have been called or not either by running `verify_on_exit`
-  from a setup block or calling `verify!/0` or `verify!/1` inline
-  in a test block.
-  """
+if Code.ensure_loaded?(Credo.Check) do
+  defmodule CredoMox.Checks.UnverifiedMox do
+    @moduledoc """
+    #{__MODULE__} looks for test files that import Mox and use
+    the `expect/4` function, but do not enforce any assertions that
+    the expectations have been called or not either by running `verify_on_exit`
+    from a setup block or calling `verify!/0` or `verify!/1` inline
+    in a test block.
+    """
 
-  @message """
-  Credo found a test file that imports Mox and uses expect/4, but no verifications were found, which means the test will never fail if the function isn't called.
-  You can verify expectations in one of two ways. The most common is to add:
-      setup :verify_on_exit!
-  at the top level of your test file. Alternatively, you can explicitly call verify!/0 or verify!/1 in each test that uses expect/4.
-  """
+    @message """
+    Credo found a test file that imports Mox and uses expect/4, but no verifications were found, which means the test will never fail if the function isn't called.
+    You can verify expectations in one of two ways. The most common is to add:
+        setup :verify_on_exit!
+    at the top level of your test file. Alternatively, you can explicitly call verify!/0 or verify!/1 in each test that uses expect/4.
+    """
 
-  @exit_status 32
-  # Set up the behaviour and make this module a "check":
-  use Credo.Check,
-    base_priority: :high,
-    category: :warning,
-    param_defaults: [],
-    explanations: [
-      check: """
-      Ensures that Mox expectations are always verified. Without either setting up
-      `:verify_on_exit!` or manually calling `verify!` after your expectations, calls to
-      `Mox.expect/4` within your test will never fail, so the test will pass regardless
-      of whether your expected function was called.
-      """,
-      params: []
-    ],
-    exit_status: @exit_status
+    @exit_status 32
+    # Set up the behaviour and make this module a "check":
+    use Credo.Check,
+      base_priority: :high,
+      category: :warning,
+      param_defaults: [],
+      explanations: [
+        check: """
+        Ensures that Mox expectations are always verified. Without either setting up
+        `:verify_on_exit!` or manually calling `verify!` after your expectations, calls to
+        `Mox.expect/4` within your test will never fail, so the test will pass regardless
+        of whether your expected function was called.
+        """,
+        params: []
+      ],
+      exit_status: @exit_status
 
-  @doc """
-  Inspects test files for the use of `Mox.expect/4` where the expectations being made are unverified.
+    @doc """
+    Inspects test files for the use of `Mox.expect/4` where the expectations being made are unverified.
 
-  If unverified expectations are found, this check will flag the test file as an issue.
-  The offending file will be displayed in the resulting issue when running `mix credo --strict`,
-  and the line number indicated in the issue will point to the first use of `expect` in that file
-  where the expectation has not been verified.
-  """
-  @impl Credo.Check
-  def run(source_file, params \\ []) do
-    issue_meta = IssueMeta.for(source_file, params)
+    If unverified expectations are found, this check will flag the test file as an issue.
+    The offending file will be displayed in the resulting issue when running `mix credo --strict`,
+    and the line number indicated in the issue will point to the first use of `expect` in that file
+    where the expectation has not been verified.
+    """
+    @impl Credo.Check
+    def run(source_file, params \\ []) do
+      issue_meta = IssueMeta.for(source_file, params)
 
-    walked_directives =
-      source_file
-      |> Credo.Code.ast()
-      |> then(fn {:ok, ast} -> Macro.postwalker(ast) end)
+      walked_directives =
+        source_file
+        |> Credo.Code.ast()
+        |> then(fn {:ok, ast} -> Macro.postwalker(ast) end)
 
-    with true <-
-           Enum.any?(walked_directives, fn ast_node ->
-             match?({:import, _, [{_, _, [:Mox]}]}, ast_node)
-           end),
-         {:expect, context, _} <-
-           find_unverified_expect(walked_directives),
-         false <-
-           Enum.any?(walked_directives, &setup_contains_verify_on_exit?/1) do
-      [issue_for("Missing verify_on_exit!", context, issue_meta)]
-    else
-      _ -> []
-    end
-  end
-
-  defp find_unverified_expect(walked_directives) do
-    Enum.find_value(walked_directives, fn ast_node ->
-      with test_block when not is_nil(test_block) <- find_test_body(ast_node),
-           {:expect, _context, _} = expect_tuple <-
-             Enum.find(test_block, &match?({:expect, _, _}, &1)),
-           false <- Enum.any?(test_block, &match?({:verify!, _, _}, &1)) do
-        expect_tuple
+      with true <-
+             Enum.any?(walked_directives, fn ast_node ->
+               match?({:import, _, [{_, _, [:Mox]}]}, ast_node)
+             end),
+           {:expect, context, _} <-
+             find_unverified_expect(walked_directives),
+           false <-
+             Enum.any?(walked_directives, &setup_contains_verify_on_exit?/1) do
+        [issue_for("Missing verify_on_exit!", context, issue_meta)]
       else
-        _ -> false
+        _ -> []
       end
-    end)
-  end
-
-  defp find_test_body(ast_node) do
-    case ast_node do
-      # multiline test without context
-      {:test, _, [_, [do: {:__block__, _context, test_body}]]} ->
-        test_body
-
-      # multiline test with context
-      {:test, _, [_, _, [do: {:__block__, _context, test_body}]]} ->
-        test_body
-
-      # singleline test without context
-      {:test, _, [_, [do: {:expect, _, _} = test_body]]} ->
-        [test_body]
-
-      # singleline test with context
-      {:test, _, [_, _, [do: {:expect, _, _} = test_body]]} ->
-        [test_body]
-
-      _ ->
-        nil
     end
-  end
 
-  defp setup_contains_verify_on_exit?({:setup, _context, [:verify_on_exit!]}), do: true
+    defp find_unverified_expect(walked_directives) do
+      Enum.find_value(walked_directives, fn ast_node ->
+        with test_block when not is_nil(test_block) <- find_test_body(ast_node),
+             {:expect, _context, _} = expect_tuple <-
+               Enum.find(test_block, &match?({:expect, _, _}, &1)),
+             false <- Enum.any?(test_block, &match?({:verify!, _, _}, &1)) do
+          expect_tuple
+        else
+          _ -> false
+        end
+      end)
+    end
 
-  defp setup_contains_verify_on_exit?({:setup, _context, [[do: block_ast]]}) do
-    Enum.any?(Macro.prewalker(block_ast), fn node ->
-      match?({:verify_on_exit!, _, _}, node)
-    end)
-  end
+    defp find_test_body(ast_node) do
+      case ast_node do
+        # multiline test without context
+        {:test, _, [_, [do: {:__block__, _context, test_body}]]} ->
+          test_body
 
-  defp setup_contains_verify_on_exit?({:setup, _context, [_, [do: block_ast]]}) do
-    Enum.any?(Macro.postwalker(block_ast), fn node ->
-      match?({:verify_on_exit!, _, _}, node)
-    end)
-  end
+        # multiline test with context
+        {:test, _, [_, _, [do: {:__block__, _context, test_body}]]} ->
+          test_body
 
-  defp setup_contains_verify_on_exit?({:setup, _context, [arguments]}) when is_list(arguments) do
-    Enum.member?(arguments, :verify_on_exit!)
-  end
+        # singleline test without context
+        {:test, _, [_, [do: {:expect, _, _} = test_body]]} ->
+          [test_body]
 
-  defp setup_contains_verify_on_exit?(_), do: false
+        # singleline test with context
+        {:test, _, [_, _, [do: {:expect, _, _} = test_body]]} ->
+          [test_body]
 
-  defp issue_for(name, context, issues_meta) do
-    format_issue(
-      issues_meta,
-      message: @message,
-      trigger: name,
-      line_no: context[:line]
-    )
+        _ ->
+          nil
+      end
+    end
+
+    defp setup_contains_verify_on_exit?({:setup, _context, [:verify_on_exit!]}), do: true
+
+    defp setup_contains_verify_on_exit?({:setup, _context, [[do: block_ast]]}) do
+      Enum.any?(Macro.prewalker(block_ast), fn node ->
+        match?({:verify_on_exit!, _, _}, node)
+      end)
+    end
+
+    defp setup_contains_verify_on_exit?({:setup, _context, [_, [do: block_ast]]}) do
+      Enum.any?(Macro.postwalker(block_ast), fn node ->
+        match?({:verify_on_exit!, _, _}, node)
+      end)
+    end
+
+    defp setup_contains_verify_on_exit?({:setup, _context, [arguments]})
+         when is_list(arguments) do
+      Enum.member?(arguments, :verify_on_exit!)
+    end
+
+    defp setup_contains_verify_on_exit?(_), do: false
+
+    defp issue_for(name, context, issues_meta) do
+      format_issue(
+        issues_meta,
+        message: @message,
+        trigger: name,
+        line_no: context[:line]
+      )
+    end
   end
 end

--- a/lib/checks/unverified_mox.ex
+++ b/lib/checks/unverified_mox.ex
@@ -8,10 +8,10 @@ defmodule CredoMox.Checks.UnverifiedMox do
   """
 
   @message """
-  Credo found a test file that imports Mox and uses expect/4, but no verifications were found. When you use expect/4, make sure that you are verifying the the mock.
-  To do this, either make sure that you also add:
-  setup :verify_on_exit!
-  to your test file, or alternatively, call verify!/0 or verify!/1 in each test that uses expect/4
+  Credo found a test file that imports Mox and uses expect/4, but no verifications were found, which means the test will never fail if the function isn't called.
+  You can verify expectations in one of two ways. The most common is to add:
+      setup :verify_on_exit!
+  at the top level of your test file. Alternatively, you can explicitly call verify!/0 or verify!/1 in each test that uses expect/4.
   """
 
   @exit_status 32
@@ -22,15 +22,22 @@ defmodule CredoMox.Checks.UnverifiedMox do
     param_defaults: [],
     explanations: [
       check: """
-      :verify_on_exit! for tests that need Mock
+      Ensures that Mox expectations are always verified. Without either setting up
+      `:verify_on_exit!` or manually calling `verify!` after your expectations, calls to
+      `Mox.expect/4` within your test will never fail, so the test will pass regardless
+      of whether your expected function was called.
       """,
       params: []
     ],
     exit_status: @exit_status
 
   @doc """
-  Inspects test files for the use of `Mox.expect/4` where the expectations being made are unverified. If unverified expectations are found, this check will flag the test file as an issue.
-  The offending file will be displayed in the resulting issue when running `mix credo --strict`, and the line number indicated in the issue will point to the first use of `expect` in that file where the expectation has not been verified.
+  Inspects test files for the use of `Mox.expect/4` where the expectations being made are unverified.
+
+  If unverified expectations are found, this check will flag the test file as an issue.
+  The offending file will be displayed in the resulting issue when running `mix credo --strict`,
+  and the line number indicated in the issue will point to the first use of `expect` in that file
+  where the expectation has not been verified.
   """
   @impl Credo.Check
   def run(source_file, params \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule CredoMox.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.7", only: [:dev, :test]},
       {:ex_doc, "~> 0.31", only: :dev, runtime: false}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule CredoMox.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:credo, "~> 1.7", only: [:dev, :test]},
+      {:credo, "~> 1.7"},
       {:ex_doc, "~> 0.31", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
There are two commits here:

1. Docs updates
    - Updates the README to add a bit more description and update the installation instructions.
    - Fixes a typo in the `.credo.exs` instructions
    - Improves the formatting of the default error
    - Improves the explanation when run with `mix credo explain`
2. Fix for an error about Credo being unavailable when using via Hex

    This looks like a total rewrite of the check, but if you review with "ignore whitespace" turned on, it's only a 2 line diff to ensure the check is loaded after Credo. Without this, I got the following error after following the installation instructions and trying to use the check:
    
    ```
    $ mix credo
    ==> credo_mox
    Compiling 1 file (.ex)
    error: module Credo.Check is not loaded and could not be found
    │
    19 │ use Credo.Check,
    │ ^^^^^^^^^^^^^^^^
    │
    └─ lib/checks/unverified_mox.ex:19: CredoMox.Checks.UnverifiedMox (module)
    
    == Compilation error in file lib/checks/unverified_mox.ex ==
    ** (CompileError) lib/checks/unverified_mox.ex: cannot compile module CredoMox.Checks.UnverifiedMox (errors have been logged)
    (elixir 1.16.2) expanding macro: Kernel.use/2
    lib/checks/unverified_mox.ex:19: CredoMox.Checks.UnverifiedMox (module)
    could not compile dependency :credo_mox, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile credo_mox --force", update it with "mix deps.update credo_mox" or clean it with "mix deps.clean credo_mox"
    ```
    
    The setup here matches another custom check I use successfully, ExcellentMigrations: https://github.com/Artur-Sulej/excellent_migrations/blob/v0.1.8/lib/credo_check/migrations_safety.ex