### PR TITLE
Fix false negatives on multi-module source files

### DIFF
--- a/test/checks/unverified_mox_test.exs
+++ b/test/checks/unverified_mox_test.exs
@@ -207,4 +207,32 @@ defmodule CredoMox.Checks.UnverifiedMoxTest do
       |> assert_issue()
     end
   end
+
+  test "warns about files with multiple modules where one module is missing verify_on_exit" do
+    """
+    defmodule CredoSampleModule1Test do
+      import Mox
+      setup :verify_on_exit!
+      describe "something" do
+        test "the thing" do
+          expect MockModule, :function, fn -> :foo end
+        end
+      end
+    end
+
+    defmodule CredoSampleModule2Test do
+      import Mox
+      describe "something" do
+        test "the thing" do
+          expect MockModule, :function, fn -> :foo end
+          expect MockModule, :function, fn -> :foo end
+          expect MockModule, :function, fn -> :foo end
+        end
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(UnverifiedMox)
+    |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
+  end
 end


### PR DESCRIPTION
This PR addresses the feedback provided in https://github.com/carsdotcom/credo_mox/issues/2. 

When running the `unverified_mox` check against a source file with multiple modules per file, the check may 
have provided a false negative (i.e., would have indicated that there was no violation of the `unverified_mox` rule) when only one of the two modules had a verified check. 

The changes made here modify the check to look at a per-module AST, searching for any cases of mox `expect` calls that were unverified. In case there are multiple modules, all with unverified calls to `expect`, the check will now indicate an issue with each module, so you may end up with more than one `unverified_mox` issue per source file.