### PR TITLE
Fix checking modules with nested names

### DIFF
--- a/lib/checks/unverified_mox.ex
+++ b/lib/checks/unverified_mox.ex
@@ -51,7 +51,7 @@ if Code.ensure_loaded?(Credo.Check) do
 
       module_directives =
         for directive <- walked_directives,
-            match?({:defmodule, _, [{_, _, [_]} | _]}, directive),
+            match?({:defmodule, _, [{_, _, [_ | _]} | _]}, directive),
             do: directive
 
       Enum.reduce(module_directives, [], fn module, issues_per_file ->

--- a/test/checks/unverified_mox_test.exs
+++ b/test/checks/unverified_mox_test.exs
@@ -39,6 +39,33 @@ defmodule CredoMox.Checks.UnverifiedMoxTest do
       |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
     end
 
+    test "warns about modules with nested names missing verify_on_exit" do
+      """
+      defmodule MyApp.MyContext.MyModuleTest do
+        import Mox
+
+        test "this one's fine" do
+          assert 1 + 1 == 2
+        end
+
+        describe "more stuff that's fine" do
+          test "math works" do
+            assert 1 + 1 == 2
+          end
+        end
+
+        describe "something" do
+          test "the thing" do
+            expect MockModule, :function, fn -> :foo end
+          end
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(UnverifiedMox)
+      |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
+    end
+
     test "does not warn about test files with verify_on_exit! inside of a setup list" do
       """
       defmodule CredoSampleModuleTest do


### PR DESCRIPTION
Hi Zack! I was excited to try v0.1.1, but then totally shocked when it found no issues. Upon further investigation, it wasn't finding *any* issues whatsoever—I could comment out the `setup verify_on_exit!` in every one of my files, but would get no issues, although I could run the tests just fine.

What it came down is that the match for module directives was only matching modules with a single-atom name, like `MyModule`, not `MyApp.MyModule`.

With this fix, I was able to find a handful of new places across the codebase where we had missed `:verify_on_exit!` calls! 🥳 