### PR TITLE
Add support for verifying Hammox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CredoMox
 
-Credo Checks to ensure correct usage of the Mox library.
+Credo Checks to ensure correct usage of the Mox and Hammox libraries.
 
-Provides a Credo check that ensures tests that have imported Mox and use the `Mox.expect/4` function
+Provides a Credo check that ensures tests that have imported Mox/Hammox and use the `expect/4` function
 are verifying those expectations. See the `CredoMox.Checks.UnverifiedMox` module for more details.
 
 ## Usage

--- a/lib/checks/unverified_mox.ex
+++ b/lib/checks/unverified_mox.ex
@@ -1,18 +1,11 @@
 if Code.ensure_loaded?(Credo.Check) do
   defmodule CredoMox.Checks.UnverifiedMox do
     @moduledoc """
-    #{__MODULE__} looks for test files that import Mox and use
+    #{__MODULE__} looks for test files that import Mox/Hammox and use
     the `expect/4` function, but do not enforce any assertions that
     the expectations have been called or not either by running `verify_on_exit`
     from a setup block or calling `verify!/0` or `verify!/1` inline
     in a test block.
-    """
-
-    @message """
-    Credo found a test file that imports Mox and uses expect/4, but no verifications were found, which means the test will never fail if the function isn't called.
-    You can verify expectations in one of two ways. The most common is to add:
-        setup :verify_on_exit!
-    at the top level of your test file. Alternatively, you can explicitly call verify!/0 or verify!/1 in each test that uses expect/4.
     """
 
     @exit_status 32
@@ -23,7 +16,7 @@ if Code.ensure_loaded?(Credo.Check) do
       param_defaults: [],
       explanations: [
         check: """
-        Ensures that Mox expectations are always verified. Without either setting up
+        Ensures that Mox/Hammox expectations are always verified. Without either setting up
         `:verify_on_exit!` or manually calling `verify!` after your expectations, calls to
         `Mox.expect/4` within your test will never fail, so the test will pass regardless
         of whether your expected function was called.
@@ -54,24 +47,25 @@ if Code.ensure_loaded?(Credo.Check) do
             match?({:defmodule, _, [{_, _, [_ | _]} | _]}, directive),
             do: directive
 
-      Enum.reduce(module_directives, [], fn module, issues_per_file ->
-        module
-        |> Macro.postwalker()
-        |> issues_per_module(issue_meta)
-        |> Enum.concat(issues_per_file)
+      Enum.flat_map(module_directives, fn module ->
+        Enum.flat_map([:Mox, :Hammox], fn mock_lib ->
+          module
+          |> Macro.postwalker()
+          |> issues_per_module(issue_meta, mock_lib)
+        end)
       end)
     end
 
-    defp issues_per_module(module_ast, issue_meta) do
+    defp issues_per_module(module_ast, issue_meta, mock_module) do
       with true <-
              Enum.any?(module_ast, fn ast_node ->
-               match?({:import, _, [{_, _, [:Mox]}]}, ast_node)
+               match?({:import, _, [{_, _, [^mock_module]}]}, ast_node)
              end),
            {:expect, context, _} <-
              find_unverified_expect(module_ast),
            false <-
              Enum.any?(module_ast, &setup_contains_verify_on_exit?/1) do
-        [issue_for("Missing verify_on_exit!", context, issue_meta)]
+        [issue_for("Missing verify_on_exit!", context, issue_meta, mock_module)]
       else
         _ -> []
       end
@@ -134,10 +128,15 @@ if Code.ensure_loaded?(Credo.Check) do
 
     defp setup_contains_verify_on_exit?(_), do: false
 
-    defp issue_for(name, context, issues_meta) do
+    defp issue_for(name, context, issues_meta, mock_module) do
       format_issue(
         issues_meta,
-        message: @message,
+        message: """
+        Credo found a test file that imports #{mock_module} and uses expect/4, but no verifications were found, which means the test will never fail if the function isn't called.
+        You can verify expectations in one of two ways. The most common is to add:
+            setup :verify_on_exit!
+        at the top level of your test file. Alternatively, you can explicitly call verify!/{0,1} in each test that uses expect/4.
+        """,
         trigger: name,
         line_no: context[:line]
       )

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule CredoMox.MixProject do
   end
 
   defp description do
-    "Credo checks for Mox"
+    "Credo checks for Mox and Hammox"
   end
 
   # Run "mix help deps" to learn about dependencies.

--- a/test/checks/unverified_mox_test.exs
+++ b/test/checks/unverified_mox_test.exs
@@ -3,11 +3,275 @@ defmodule CredoMox.Checks.UnverifiedMoxTest do
 
   alias CredoMox.Checks.UnverifiedMox
 
-  describe "UnverifiedMox Check" do
-    test "does NOT warn when a mock is verified" do
+  for mock_lib <- [:Mox, :Hammox] do
+    describe "UnverifiedMox Check for #{mock_lib}" do
+      @describetag mock_lib: mock_lib
+      test "does NOT warn when a mock is verified", %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          setup :verify_on_exit!
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "warns about test files without verify_on_exit if `expect` is present", %{
+        mock_lib: mock_lib
+      } do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+              expect MockModule, :function, fn -> :foo end
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
+      end
+
+      test "warns about modules with nested names missing verify_on_exit", %{mock_lib: mock_lib} do
+        """
+        defmodule MyApp.MyContext.MyModuleTest do
+          import #{mock_lib}
+
+          test "this one's fine" do
+            assert 1 + 1 == 2
+          end
+
+          describe "more stuff that's fine" do
+            test "math works" do
+              assert 1 + 1 == 2
+            end
+          end
+
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
+      end
+
+      test "does not warn about test files with verify_on_exit! inside of a setup list", %{
+        mock_lib: mock_lib
+      } do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          setup [:set_mox_from_context, :verify_on_exit!]
+
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+              expect MockModule, :function, fn -> :foo end
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "does not warn about test files with verify_on_exit! inside of a setup block that takes a context",
+           %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+
+          setup context do
+            _ = my_function(context)
+
+            _ = verify_on_exit!(context)
+
+            {:ok, data: 1}
+          end
+
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "does not warn about test files with verify_on_exit! inside of a setup block that doesn't take a context",
+           %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+
+          setup do
+            _ = my_function()
+
+            _ = verify_on_exit!()
+
+            {:ok, data: 1}
+          end
+
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "does not warn about test files without verify_on_exit if no `expect` call is present",
+           %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          describe "something" do
+            test "the thing" do
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "does not warn about tests with an `expect` call if the test itself calls verify!/0",
+           %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+              verify!()
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "does not warn about tests with an `expect` call if the test itself calls verify!/1",
+           %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+              verify!(MockModule)
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "does not warn about other imported expect functions" do
+        """
+        defmodule CredoSampleModuleTest do
+          import SomeOtherMockingLib
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> refute_issues()
+      end
+
+      test "warns about tests with an `expect` call but no call to `verify` when the test has context",
+           %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          describe "something" do
+            test "the thing", %{foo: bar} do
+              "not a single line test anymore"
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> assert_issue()
+      end
+
+      test "warns about tests with an `expect` and no `verify` when the test is a single line", %{
+        mock_lib: mock_lib
+      } do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          describe "something" do
+            test "the thing" do
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> assert_issue()
+      end
+
+      test "warns about tests with a call to `expect` but no `verify` when the test is a single line and has context",
+           %{mock_lib: mock_lib} do
+        """
+        defmodule CredoSampleModuleTest do
+          import #{mock_lib}
+          describe "something" do
+            test "the thing", %{foo: bar} do
+              expect MockModule, :function, fn -> :foo end
+            end
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(UnverifiedMox)
+        |> assert_issue()
+      end
+    end
+
+    @tag mock_lib: mock_lib
+    test "warns about files with multiple modules where one module is missing verify_on_exit (#{mock_lib})",
+         %{mock_lib: mock_lib} do
       """
-      defmodule CredoSampleModuleTest do
-        import Mox
+      defmodule CredoSampleModule1Test do
+        import #{mock_lib}
         setup :verify_on_exit!
         describe "something" do
           test "the thing" do
@@ -15,16 +279,9 @@ defmodule CredoMox.Checks.UnverifiedMoxTest do
           end
         end
       end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> refute_issues()
-    end
 
-    test "warns about test files without verify_on_exit if `expect` is present " do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
+      defmodule CredoSampleModule2Test do
+        import #{mock_lib}
         describe "something" do
           test "the thing" do
             expect MockModule, :function, fn -> :foo end
@@ -38,228 +295,5 @@ defmodule CredoMox.Checks.UnverifiedMoxTest do
       |> run_check(UnverifiedMox)
       |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
     end
-
-    test "warns about modules with nested names missing verify_on_exit" do
-      """
-      defmodule MyApp.MyContext.MyModuleTest do
-        import Mox
-
-        test "this one's fine" do
-          assert 1 + 1 == 2
-        end
-
-        describe "more stuff that's fine" do
-          test "math works" do
-            assert 1 + 1 == 2
-          end
-        end
-
-        describe "something" do
-          test "the thing" do
-            expect MockModule, :function, fn -> :foo end
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
-    end
-
-    test "does not warn about test files with verify_on_exit! inside of a setup list" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-        setup [:set_mox_from_context, :verify_on_exit!]
-
-        describe "something" do
-          test "the thing" do
-            expect MockModule, :function, fn -> :foo end
-            expect MockModule, :function, fn -> :foo end
-            expect MockModule, :function, fn -> :foo end
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> refute_issues()
-    end
-
-    test "does not warn about test files with verify_on_exit! inside of a setup block that takes a context" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-
-        setup context do
-          _ = my_function(context)
-
-          _ = verify_on_exit!(context)
-
-          {:ok, data: 1}
-        end
-
-        describe "something" do
-          test "the thing" do
-            expect MockModule, :function, fn -> :foo end
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> refute_issues()
-    end
-
-    test "does not warn about test files with verify_on_exit! inside of a setup block that doesn't take a context" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-
-        setup do
-          _ = my_function()
-
-          _ = verify_on_exit!()
-
-          {:ok, data: 1}
-        end
-
-        describe "something" do
-          test "the thing" do
-            expect MockModule, :function, fn -> :foo end
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> refute_issues()
-    end
-
-    test "does not warn about test files without verify_on_exit if no `expect` call is present" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-        describe "something" do
-          test "the thing" do
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> refute_issues()
-    end
-
-    test "does not warn about tests with an `expect` call if the test itself calls verify!/0" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-        describe "something" do
-          test "the thing" do
-            expect MockModule, :function, fn -> :foo end
-            verify!()
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> refute_issues()
-    end
-
-    test "does not warn about tests with an `expect` call if the test itself calls verify!/1" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-        describe "something" do
-          test "the thing" do
-            expect MockModule, :function, fn -> :foo end
-            verify!(MockModule)
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> refute_issues()
-    end
-
-    test "warns about tests with an `expect` call but no call to `verify` when the test has context" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-        describe "something" do
-          test "the thing", %{foo: bar} do
-            "not a single line test anymore"
-            expect MockModule, :function, fn -> :foo end
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> assert_issue()
-    end
-
-    test "warns about tests with an `expect` and no `verify` when the test is a single line" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-        describe "something" do
-          test "the thing" do
-            expect MockModule, :function, fn -> :foo end
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> assert_issue()
-    end
-
-    test "warns about tests with a call to `expect` but no `verify` when the test is a single line and has context" do
-      """
-      defmodule CredoSampleModuleTest do
-        import Mox
-        describe "something" do
-          test "the thing", %{foo: bar} do
-            expect MockModule, :function, fn -> :foo end
-          end
-        end
-      end
-      """
-      |> to_source_file()
-      |> run_check(UnverifiedMox)
-      |> assert_issue()
-    end
-  end
-
-  test "warns about files with multiple modules where one module is missing verify_on_exit" do
-    """
-    defmodule CredoSampleModule1Test do
-      import Mox
-      setup :verify_on_exit!
-      describe "something" do
-        test "the thing" do
-          expect MockModule, :function, fn -> :foo end
-        end
-      end
-    end
-
-    defmodule CredoSampleModule2Test do
-      import Mox
-      describe "something" do
-        test "the thing" do
-          expect MockModule, :function, fn -> :foo end
-          expect MockModule, :function, fn -> :foo end
-          expect MockModule, :function, fn -> :foo end
-        end
-      end
-    end
-    """
-    |> to_source_file()
-    |> run_check(UnverifiedMox)
-    |> assert_issue(fn issue -> assert issue.trigger == "Missing verify_on_exit!" end)
   end
 end


### PR DESCRIPTION
Hi there! 👋 I happily used the Credo check at a past employer, but at my new job, we use Hammox rather than Mox.

Since the API for Hammox is almost identical to Mox, this PR simply substitutes the library name and runs the same checks for Hammox.

## Sample from my codebase

<img width="749" height="501" alt="Screenshot 2025-09-17 at 9 00 47 AM" src="https://github.com/user-attachments/assets/f4e3d818-f7cd-4ed1-85d6-49d2394b7e68" />
